### PR TITLE
Fix BrowserModule Duplicate Error

### DIFF
--- a/src/popover.module.ts
+++ b/src/popover.module.ts
@@ -1,4 +1,4 @@
-import { BrowserModule } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { TooltipDirective } from './tooltip/tooltip.directive';
@@ -23,7 +23,7 @@ import { Popover, PopoverContent } from 'ngx-popover';
     InlineDialogDirective
   ],
   imports: [
-    BrowserModule
+    CommonModule
   ],
   providers: [],
   entryComponents: [TooltipComponent],


### PR DESCRIPTION
Change the BrowserModule to CommonModule to prevent the duplicate BrowserModule loading error when importing the popover module.